### PR TITLE
[PENG-739] Integrate Aikido Safe Chain into CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
         cache: true
     - name: Install Cosign
       uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
+    - name: Setup Aikido Safe Chain
+      run: |
+        curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.4.7/install-safe-chain.sh | sh -s -- --ci
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
       with:


### PR DESCRIPTION
## Summary
- Added Aikido Safe Chain setup step to the `release.yml` workflow before the GoReleaser step (which triggers dependency resolution and build)
- `build.yml` was skipped as it is entirely commented out (inactive)
- Aikido Safe Chain enables supply chain security scanning for Go module dependencies during CI

## Test plan
- [ ] Verify the `release.yml` workflow runs successfully on a tag push
- [ ] Confirm Aikido Safe Chain initializes correctly before GoReleaser executes
- [ ] Validate that no existing workflow behavior is disrupted

🤖 Generated with [Claude Code](https://claude.com/claude-code)